### PR TITLE
add gamma coefficient and kazemi window

### DIFF
--- a/stockwell/c_libs/my_types.h
+++ b/stockwell/c_libs/my_types.h
@@ -1,0 +1,2 @@
+enum WINDOW {GAUSS, KAZEMI};
+// extern enum WINDOW window_type;

--- a/stockwell/c_libs/st.c
+++ b/stockwell/c_libs/st.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <math.h>
 #include <fftw3.h>
+#include "my_types.h"
 
 char *Wisfile = NULL;
 char *Wistemplate = "%s/.fftwis";
@@ -31,7 +32,8 @@ int st_freq(double f, int len, double srate)
 	return floor(f * len / srate + .5);
 }
 
-static double gauss(int n, int m);
+static double gauss(int n, int m, double gamma);
+static double kazemi(int n, int m, double gamma);
 
 /* Stockwell transform of the real array data. The len argument is the
 number of time points, and it need not be a power of two. The lo and hi
@@ -41,7 +43,7 @@ returned in the complex array result, which must be preallocated, with
 n rows and len columns, where n is hi - lo + 1. For the default values of
 lo and hi, n is len / 2 + 1. */
 
-void st(int len, int lo, int hi, double *data, double *result)
+void st(int len, int lo, int hi, double gamma, enum WINDOW window_code, double *data, double *result)
 {
 	int i, k, n, l2;
 	double s, *p;
@@ -50,7 +52,13 @@ void st(int len, int lo, int hi, double *data, double *result)
 	static double *g;
 	static fftw_plan p1, p2;
 	static fftw_complex *h, *H, *G;
-
+	static double (*window_function)(int, int, double);
+	window_function = &gauss;
+	if (window_code == KAZEMI)
+	{
+		window_function = &kazemi;
+	}
+	
 	/* Check for frequency defaults. */
 
 	if (lo == 0 && hi == 0) {
@@ -152,10 +160,10 @@ void st(int len, int lo, int hi, double *data, double *result)
 		/* Scale the FFT of the gaussian. Negative frequencies
 		wrap around. */
 
-		g[0] = gauss(n, 0);
+		g[0] = (*window_function)(n, 0, gamma);
 		l2 = len / 2 + 1;
 		for (i = 1; i < l2; i++) {
-			g[i] = g[len - i] = gauss(n, i);
+			g[i] = g[len - i] = (*window_function)(n, i, gamma);
 		}
 
 		for (i = 0; i < len; i++) {
@@ -182,10 +190,17 @@ void st(int len, int lo, int hi, double *data, double *result)
 
 /* This is the Fourier Transform of a Gaussian. */
 
-static double gauss(int n, int m)
+static double gauss(int n, int m, double gamma)
 {
-	return exp(-2. * M_PI * M_PI * m * m / (n * n));
+	return exp(-2. * M_PI * M_PI * m * m * gamma * gamma / (n * n));
 }
+
+/* This is the Fourier Transform of a Kazemi window. */
+static double kazemi(int n, int m, double gamma)
+{
+	return 1/(1+((m * m * gamma  / n) * (m * m * gamma  / n)));
+}
+
 
 /* Inverse Stockwell transform. */
 

--- a/stockwell/c_libs/stmodule.c
+++ b/stockwell/c_libs/stmodule.c
@@ -8,31 +8,43 @@
  */
 
 /* Stockwell Transform wrapper code. */
-
+#include <string.h>
+#include <stdio.h>
 #include <Python.h>
 #include <numpy/arrayobject.h>
+#include "my_types.h"
 
-extern void st(int, int, int, double *, double *);
+extern void st(int, int, int, double, enum WINDOW window_code, double *, double *);
 extern void ist(int, int, int, double *, double *);
 extern void hilbert(int, double *, double *);
 
 static char Doc_st[] =
-"st(x[, lo, hi]) returns the 2d, complex Stockwell transform of the real\n\
+"st(x[, gamma, window type, lo, hi]) returns the 2d, complex Stockwell transform of the real\n\
 array x. If lo and hi are specified, only those frequencies (rows) are\n\
-returned; lo and hi default to 0 and n/2, resp., where n is the length of x.";
+returned; lo and hi default to 0 and n/2, resp., where n is the length of x.\n\
+Gamma coeficcfent is set default to 1. Gamma is the adjustable parameter, \n\
+which has been defined to tune the time and frequency resolutions of the S-transform. \n\
+It presents the number of Fourier sinusoidal periods within one standard deviation of the Gaussian window. \n\
+Raising gamma increases the frequency resolution and consequently decreases the time resolution of the S-transform and vice versa (Kazemi, 2014). \n\
+Two window types available: gauss (default) and kazemi (Kazemi, 2014).";
 
 static PyObject *st_wrap(PyObject *self, PyObject *args)
 {
 	int n, dim[2];
 	int lo = 0;
 	int hi = 0;
+	double gamma = 1;
+	char *win_type;
+	char buff[10];
 	PyObject *o;
 	PyArrayObject *a, *r;
-
-	if (!PyArg_ParseTuple(args, "O|ii", &o, &lo, &hi)) {
+	enum WINDOW window_type = GAUSS;
+	if (!PyArg_ParseTuple(args, "O|sdii", &o, &win_type, &gamma, &lo, &hi)) {
 		return NULL;
 	}
-
+	if(strcmp(win_type, "kazemi") == 0){
+		window_type = KAZEMI;
+	}
 	a = (PyArrayObject *)
 		PyArray_ContiguousFromObject(o, PyArray_DOUBLE, 1, 1);
 	if (a == NULL) {
@@ -51,8 +63,7 @@ static PyObject *st_wrap(PyObject *self, PyObject *args)
 		Py_DECREF(a);
 		return NULL;
 	}
-
-	st(n, lo, hi, (double *)a->data, (double *)r->data);
+	st(n, lo, hi, gamma, window_type, (double *)a->data, (double *)r->data);
 
 	Py_DECREF(a);
 	return PyArray_Return(r);


### PR DESCRIPTION
I added a factor gamma to tune the time and frequency resolutions of the S-transform. Additionally I implemented a function with different type of window, presented in "The S-transform using a new window to improve frequency and time resolutions" (Kazemi, 2014). Example python usage:
`gamma = 1.3 `
`window = 'gauss' # or 'kazemi'`
`st.st(data, window, gamma, 100, 1800)`